### PR TITLE
CORE-858 fix: ignore spurious updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 sniff
 .wercker
 vendor
+build
+.reviewboardrc

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,204 +2,465 @@
 
 
 [[projects]]
+  digest = "1:7020b5857474f4cd4ac3326eb0fc8bcf2a639ed0a732b42dce9083afea1e2e54"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = ""
   revision = "8a290539e2e8629dbc4e6bad948158f790ec31f4"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:eefdb56f035de98e76cc8b7d154faf3ac0aa1db212f789cf17454775249c8254"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = ""
   revision = "5bd2802263f21d8788851d5305584c82a5c75d7e"
 
 [[projects]]
   branch = "master"
+  digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:3734a927c8a61903115e561a1a7860153e5c02b4f80f21b13467a42759f04ac5"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 
 [[projects]]
+  digest = "1:29d00f4e339b0ae6e05bf1e3a43c0064fc7374e77417d1866cc362252bd2f6d2"
   name = "github.com/emicklei/go-restful"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log",
+  ]
+  pruneopts = ""
   revision = "ff4f55a206334ef123e4f79bbf348980da81ca46"
 
 [[projects]]
+  digest = "1:cad2dd7061b8dcb4e0014d89e8070f185fb70ac9ba26acf27ff42b9c3eb0ff9b"
   name = "github.com/emicklei/go-restful-swagger12"
   packages = ["."]
+  pruneopts = ""
   revision = "dcef7f55730566d41eae5db10e7d6981829720f6"
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:a31fbb19d2b38d50bc125d97b7c3e7a286d3f6f37d18756011eb6e7d1a9fa7d0"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
 
 [[projects]]
+  digest = "1:d5684de69d41b91bbc4582447389b6e3d422a856c7863e2cb69e83fa22585686"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = ""
   revision = "46af16f9f7b149af66e5d1bd010e3574dc06de98"
 
 [[projects]]
+  digest = "1:880132ce271710075e3dd41e5b267fb444feb4d3f6a2a6031227af8cadfa4ad0"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = ""
   revision = "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272"
 
 [[projects]]
+  digest = "1:2d7624c60176d2eefb4d5029163002282de792172273cd965d8d3ce2dfcd1ccf"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = ""
   revision = "6aced65f8501fe1217321abf0749d354824ba2ff"
 
 [[projects]]
+  digest = "1:60a4d50770b16e62199e9acad6bc92b6835d93538545933d48fc7adf0f4d8edb"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = ""
   revision = "1d0bd113de87027671077d3c71eb3ac5d7dbba72"
 
 [[projects]]
+  digest = "1:91ea659283519bfbcc8d428ecbae5475394a48f8209f5c5cd20fee169b37a63a"
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = ""
   revision = "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 
 [[projects]]
   branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:5126907b5a6192e00ab27ceae807c53d7ff61343f15308dbe09621d12231da02"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
   revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
 
 [[projects]]
+  digest = "1:a2823c34933d4a2b36284f617f483d51fe156a443923284b3660f183dcfa3338"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = ""
   revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 
 [[projects]]
+  digest = "1:02350ac468c148841775f48dbfc8155bf02bfecefac1dc6fe676ac2a314f5451"
   name = "github.com/googleapis/gnostic"
-  packages = ["OpenAPIv2","compiler","extensions"]
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions",
+  ]
+  pruneopts = ""
   revision = "68f4ded48ba9414dab2ae69b3f0d69971da73aa5"
 
 [[projects]]
+  digest = "1:9830c3ef8075a224fca4ed2d3761b58b3759310343d028223779dea21e139893"
   name = "github.com/hashicorp/golang-lru"
-  packages = [".","simplelru"]
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = ""
   revision = "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
 
 [[projects]]
   branch = "master"
+  digest = "1:f81c8d7354cc0c6340f2f7a48724ee6c2b3db3e918ecd441c985b4d2d97dd3e7"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = ""
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
+  digest = "1:af7e132906cb360f4d7c34a9e1434825467f21c4ff5c521ad4cc5b55352876a8"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 
 [[projects]]
   branch = "master"
+  digest = "1:fbafcd485d270fc069d738bdcbfa3e03676936f837d4b2708f7ba80fa90e1c5a"
   name = "github.com/juju/ratelimit"
   packages = ["."]
+  pruneopts = ""
   revision = "5b9ff866471762aa2ab2dced63c9fb6f53921342"
 
 [[projects]]
+  digest = "1:5f3c38b5f2dd7bec9286e00c3ac7babbe68859cc0edc4d3e3ba3fda93c24d7e7"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = ""
   revision = "d5b7844b561a7bc640052f1b935f7b800330d7e0"
 
 [[projects]]
   branch = "master"
+  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
 
 [[projects]]
+  branch = "master"
+  digest = "1:9ba74ff5f230fea8334355fa4de8b4e2b5e28d8c9d26f5dfa45dced464423299"
+  name = "github.com/platform9/cnxmd"
+  packages = ["pkg/cnxmd"]
+  pruneopts = ""
+  revision = "7186902f4d009ec978bc2511f872ef115afdb61c"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5a5964a5d1ee1eebd6000214134b8a351afdb07dc75c8bf213c17d0d1274b514"
+  name = "github.com/platform9/proxylib"
+  packages = ["pkg/proxylib"]
+  pruneopts = ""
+  revision = "adc2169aeeceabbb71a6b9027b99077812d18bff"
+
+[[projects]]
+  digest = "1:a12940312e8e102ea15e194704e0b74a45719b0112f911e00046d807d8481957"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = ""
   revision = "26b897001974f2b4ee6688377873e4d6f61d533c"
 
 [[projects]]
   branch = "master"
+  digest = "1:2c2e0c749aa376a90cd48f4b62b55763214f3bb16d2de7eef981062892f61619"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "6f3806018612930941127f2a7c6c453ba2c527d2"
 
 [[projects]]
+  digest = "1:bb155e0e83eb27465503e71a486a950a1b9de7de9413cf411927a3f05334c7b6"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
   revision = "3e6a7635bac6573d43f49f97b47eb9bda195dba8"
 
 [[projects]]
   branch = "master"
+  digest = "1:e5e51236fd16fb017b660ea5f473c5fc51ab3f5926285e645c4ad52bd78b12b3"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs",
+  ]
+  pruneopts = ""
   revision = "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2"
 
 [[projects]]
+  digest = "1:11705e15791a8855c4b81839cbd71722b82f0304bf5e4225c878e6961c0d4c25"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
 
 [[projects]]
+  digest = "1:cb2800cd5716e9d6172888e0e3ffe1f9c07b7f142eb83d49a391029bcf4f6cc1"
   name = "github.com/ugorji/go"
   packages = ["codec"]
+  pruneopts = ""
   revision = "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
 
 [[projects]]
+  digest = "1:0f67b4bbcdf1caaee0450f225a53fd2c2f8793578cc7810eb09c290e008e33ac"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "d172538b2cfce0c13cee31e647d0367aa8cd2486"
 
 [[projects]]
+  digest = "1:605a34a4f37423103eecd6932f2620723d2988e5d0f2b0a568ff6a5d5524610d"
   name = "golang.org/x/net"
-  packages = ["http2","http2/hpack","idna","lex/httplex"]
+  packages = [
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex",
+  ]
+  pruneopts = ""
   revision = "f2499483f923065a842d38eb4c7f1927e6fc6e6d"
 
 [[projects]]
+  digest = "1:b6e4bf8197b5de25f2ed05c603d39d619f4c41bb4a573ef5274c3446df44d6e4"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9"
 
 [[projects]]
+  digest = "1:9fa38bfa647dffc304504ea076b54f7eeb28f7ff7476536695abffcc1addd6d1"
   name = "golang.org/x/text"
-  packages = ["cases","internal/gen","internal/tag","internal/triegen","internal/ucd","language","runes","secure/bidirule","secure/precis","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "cases",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "runes",
+    "secure/bidirule",
+    "secure/precis",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width",
+  ]
+  pruneopts = ""
   revision = "2910a502d2bf9e43193af9d68ca516529614eed3"
 
 [[projects]]
+  digest = "1:e5d1fb981765b6f7513f793a3fcaac7158408cca77f75f7311ac82cc88e9c445"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = ""
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
   version = "v0.9.0"
 
 [[projects]]
+  digest = "1:10cf86195bddd2e0d686eec4fb35f35510baf6ce8393cbcfb664b9b88db7d747"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "53feefa2559fb8dfa8d81baad31be332c97d6c77"
 
 [[projects]]
+  digest = "1:1131b7c8c51246d220d8e9661e8664c54f95b10f4076e5d4025e369ede115c0c"
   name = "k8s.io/api"
-  packages = ["admissionregistration/v1alpha1","apps/v1beta1","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2alpha1","batch/v1","batch/v2alpha1","certificates/v1beta1","core/v1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1alpha1","rbac/v1beta1","settings/v1alpha1","storage/v1","storage/v1beta1"]
+  packages = [
+    "admissionregistration/v1alpha1",
+    "apps/v1beta1",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2alpha1",
+    "batch/v1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1beta1",
+  ]
+  pruneopts = ""
   revision = "4fe9229aaa9d704f8a2a21cdcd50de2bbb6e1b57"
 
 [[projects]]
+  digest = "1:2dd39ace813944795646f6eaf757124b31e3ca180615893ec631ae8670be3750"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/conversion/unstructured","pkg/fields","pkg/labels","pkg/openapi","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/cache","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/equality",
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1alpha1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/conversion/unstructured",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/openapi",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/cache",
+    "pkg/util/clock",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = ""
   revision = "8a1a257c3a3503c77f25e5802e96e89a2a11ad61"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d1520bd157d0333402cb7be8d440ac111443666409c49bb1a33201233f3ec3e"
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api/v1/ref","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2alpha1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/api/v1/ref",
+    "pkg/version",
+    "rest",
+    "rest/watch",
+    "tools/auth",
+    "tools/cache",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "transport",
+    "util/cert",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+  ]
+  pruneopts = ""
   revision = "d03136c067423d216274eff98f834e385bec6225"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "be6b91d6d27b60f1350837945b9e0fc9c5713af050837bbe6b5d180eb5231d5a"
+  input-imports = [
+    "github.com/golang/glog",
+    "github.com/platform9/cnxmd/pkg/cnxmd",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
-
 SRC_DIR=$(shell pwd)
 BUILD_DIR=$(SRC_DIR)/build
 BIN_DIR=$(BUILD_DIR)/bin
-BUILD_SRC_DIR=$(BUILD_DIR)/src/github.com/kubermatic
-K8SNIFF_SRC_DIR=$(BUILD_SRC_DIR)/k8sniff
 K8SNIFF_EXE=$(BIN_DIR)/k8sniff
-GOSRC=$(GOPATH_DIR)/src
+GOSRC=$(GOPATH)/src
+K8SNIFF_SRC_DIR=$(GOSRC)/github.com/kubermatic/k8sniff
+DEP_SRC=$(GOSRC)/github.com/golang/dep
+DEP_EXE=$(DEP_SRC)/cmd/dep/dep
+VENDOR_DIR=$(K8SNIFF_SRC_DIR)/vendor
 
 GO_DEPS := \
-	$(GOSRC)/github.com/prometheus/client_golang \
-	$(GOSRC)/github.com/platform9/cnxmd \
-	$(GOSRC)/github.com/golang/glog
+	$(GOSRC)/github.com/golang/glog \
+	$(GOSRC)/github.com/prometheus/client_golang/prometheus \
+	$(GOSRC)/github.com/platform9/cnxmd/pkg/cnxmd
 
 $(GO_DEPS): $(GOPATH_DIR)
 	go get $(subst $(GOSRC)/,,$@)
@@ -19,15 +20,17 @@ $(GO_DEPS): $(GOPATH_DIR)
 K8SNIFF_IMAGE_TAG ?= platform9systems/k8sniff
 K8SNIFF_DEVEL_IMAGE_TAG ?= platform9systems/k8sniff-devel
 
-$(BUILD_SRC_DIR):
-	mkdir -p $@
+$(DEP_SRC):
+	go get -u github.com/golang/dep/cmd/dep
 
-$(K8SNIFF_SRC_DIR): | $(BUILD_SRC_DIR)
-	mkdir -p $@
-	cp -a $(SRC_DIR)/{cmd,pkg} $@/
+$(DEP_EXE): | $(DEP_SRC)
+	cd $(DEP_SRC)/cmd/dep && go build
 
 $(BIN_DIR):
 	mkdir -p $@
+
+$(VENDOR_DIR): $(DEP_EXE)
+	$(DEP_EXE) ensure
 
 local-k8sniff:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -o $${GOPATH}/bin/k8sniff
@@ -35,13 +38,13 @@ local-k8sniff:
 local-k8sniff-dbg:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -gcflags='-N -l' -o $${GOPATH}/bin/k8sniff-dbg
 
-$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS)
+$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS) $(VENDOR_DIR)
 	go build -o $(K8SNIFF_EXE)
 
 k8sniff: $(K8SNIFF_EXE)
 
 clean:
-	rm -rf $(BUILD_DIR)
+	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(GO_DEPS)
 
 k8sniff-clean:
 	rm -f $(K8SNIFF_EXE)

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,6 @@ IMAGE_TAG ?= $(VERSION)-$(BUILD_ID)
 FULL_TAG := $(REPO_TAG):$(IMAGE_TAG)
 TAG_FILE := $(BUILD_DIR)/container-full-tag
 
-GO_DEPS := \
-	$(GOSRC)/github.com/golang/glog \
-	$(GOSRC)/github.com/prometheus/client_golang/prometheus \
-	$(GOSRC)/github.com/platform9/cnxmd/pkg/cnxmd
-
-$(GO_DEPS): $(GOPATH_DIR)
-	go get $(subst $(GOSRC)/,,$@)
-
 $(DEP_SRC):
 	go get -u github.com/golang/dep/cmd/dep
 
@@ -46,13 +38,19 @@ local-k8sniff:
 local-k8sniff-dbg:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -gcflags='-N -l' -o $${GOPATH}/bin/k8sniff-dbg
 
-$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS) $(VENDOR_DIR)
+$(K8SNIFF_EXE): | $(BIN_DIR) $(VENDOR_DIR)
 	go build -o $(K8SNIFF_EXE)
+
+dep: $(DEP_EXE)
 
 k8sniff: $(K8SNIFF_EXE)
 
 clean:
-	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(TAG_FILE)
+	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR)
+
+# dangerous: use with care. For testing
+clean-go-deps:
+	cd $(GOPATH)/src/github.com && ls | grep -v kubermatic | xargs rm -rf
 
 k8sniff-clean:
 	rm -f $(K8SNIFF_EXE)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ BUILD_SRC_DIR=$(BUILD_DIR)/src/github.com/kubermatic
 K8SNIFF_SRC_DIR=$(BUILD_SRC_DIR)/k8sniff
 K8SNIFF_EXE=$(BIN_DIR)/k8sniff
 
+GO_DEPS := \
+	$(GOSRC)/github.com/prometheus/client_golang \
+	$(GOSRC)/github.com/platform9/cnxmd \
+	$(GOSRC)/github.com/golang/glog
+
+$(GO_DEPS): $(GOPATH_DIR)
+	go get $(subst $(GOSRC)/,,$@)
+
 # Override with your own Docker registry tag(s)
 K8SNIFF_IMAGE_TAG ?= platform9systems/k8sniff
 K8SNIFF_DEVEL_IMAGE_TAG ?= platform9systems/k8sniff-devel
@@ -26,7 +34,7 @@ local-k8sniff:
 local-k8sniff-dbg:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -gcflags='-N -l' -o $${GOPATH}/bin/k8sniff-dbg
 
-$(K8SNIFF_EXE): | $(BIN_DIR)
+$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS)
 	go build -o $(K8SNIFF_EXE)
 
 k8sniff: $(K8SNIFF_EXE)

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,7 @@ $(TAG_FILE): $(K8SNIFF_EXE)
 image: $(TAG_FILE)
 
 push: $(TAG_FILE)
-	docker push `cat $(TAG_FILE)` && docker rmi `cat $(TAG_FILE)`
+	(docker push $(FULL_TAG) || \
+		(echo -n $${DOCKER_PASSWORD} | docker login --password-stdin -u $${DOCKER_USERNAME} && \
+		docker push $(FULL_TAG) && docker logout))
+	docker rmi $(FULL_TAG)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BIN_DIR=$(BUILD_DIR)/bin
 BUILD_SRC_DIR=$(BUILD_DIR)/src/github.com/kubermatic
 K8SNIFF_SRC_DIR=$(BUILD_SRC_DIR)/k8sniff
 K8SNIFF_EXE=$(BIN_DIR)/k8sniff
+GOSRC=$(GOPATH_DIR)/src
 
 GO_DEPS := \
 	$(GOSRC)/github.com/prometheus/client_golang \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+
+SRC_DIR=$(shell pwd)
+BUILD_DIR=$(SRC_DIR)/build
+BIN_DIR=$(BUILD_DIR)/bin
+BUILD_SRC_DIR=$(BUILD_DIR)/src/github.com/kubermatic
+K8SNIFF_SRC_DIR=$(BUILD_SRC_DIR)/k8sniff
+K8SNIFF_EXE=$(BIN_DIR)/k8sniff
+
+# Override with your own Docker registry tag(s)
+K8SNIFF_IMAGE_TAG ?= platform9systems/k8sniff
+K8SNIFF_DEVEL_IMAGE_TAG ?= platform9systems/k8sniff-devel
+
+$(BUILD_SRC_DIR):
+	mkdir -p $@
+
+$(K8SNIFF_SRC_DIR): | $(BUILD_SRC_DIR)
+	mkdir -p $@
+	cp -a $(SRC_DIR)/{cmd,pkg} $@/
+
+$(BIN_DIR):
+	mkdir -p $@
+
+local-k8sniff:
+	cd $(SRC_DIR)/cmd/k8sniff && go build -o $${GOPATH}/bin/k8sniff
+
+local-k8sniff-dbg:
+	cd $(SRC_DIR)/cmd/k8sniff && go build -gcflags='-N -l' -o $${GOPATH}/bin/k8sniff-dbg
+
+$(K8SNIFF_EXE): | $(BIN_DIR)
+	go build -o $(K8SNIFF_EXE)
+
+k8sniff: $(K8SNIFF_EXE)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+k8sniff-clean:
+	rm -f $(K8SNIFF_EXE)
+
+k8sniff-image: $(K8SNIFF_EXE)
+	docker build --tag $(K8SNIFF_IMAGE_TAG) -f support/Dockerfile .
+	docker push $(K8SNIFF_IMAGE_TAG)
+
+k8sniff-image-devel: $(K8SNIFF_EXE)
+	docker build --tag $(K8SNIFF_DEVEL_IMAGE_TAG) -f support/k8sniff-devel/Dockerfile .
+	docker push $(K8SNIFF_DEVEL_IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS) $(VENDOR_DIR)
 k8sniff: $(K8SNIFF_EXE)
 
 clean:
-	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(GO_DEPS)
+	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(TAG_FILE)
 
 k8sniff-clean:
 	rm -f $(K8SNIFF_EXE)
@@ -64,4 +64,4 @@ $(TAG_FILE): $(K8SNIFF_EXE)
 image: $(TAG_FILE)
 
 push: $(TAG_FILE)
-	docker push `cat $(TAG_FILE)` && rm -f $(TAG_FILE)
+	docker push `cat $(TAG_FILE)` && docker rmi `cat $(TAG_FILE)`

--- a/config.go
+++ b/config.go
@@ -85,11 +85,12 @@ type Bind struct {
 }
 
 type Server struct {
-	Default bool
-	Regexp  bool
-	Host    string
-	Names   []string
-	Port    int
+	Default     bool
+	Regexp      bool
+	Host        string
+	Names       []string
+	IngressName string
+	Port        int
 }
 
 // Valid returns an error if the metrics config is invalid

--- a/metrics/backends.go
+++ b/metrics/backends.go
@@ -11,8 +11,37 @@ var (
 			Help: "Number of configured backends",
 		},
 	)
+	backendBytesSentCtr = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: Prefix + "backend_bytes_sent_total",
+			Help: "Number of bytes sent to a given backend",
+		},
+		[]string{"backend"},
+	)
+	backendBytesRcvdCtr = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: Prefix + "backend_bytes_received_total",
+			Help: "Number of bytes received from a given backend",
+		},
+		[]string{"backend"},
+	)
 )
 
 func SetBackendCount(count int) {
 	backendGauge.Set(float64(count))
 }
+
+// AddBackendBytesSent adds the total bytes relayed from k8sniff to the
+// given backend
+func AddBackendBytesSent(backend string, numBytes int64) {
+	g, _ := backendBytesSentCtr.GetMetricWithLabelValues(backend)
+	g.Add(float64(numBytes))
+}
+
+// AddBackendBytesRcvd adds the total bytes copied from the given backend
+// to the client
+func AddBackendBytesRcvd(backend string, numBytes int64) {
+	g, _ := backendBytesRcvdCtr.GetMetricWithLabelValues(backend)
+	g.Add(float64(numBytes))
+}
+

--- a/metrics/connections.go
+++ b/metrics/connections.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -17,6 +16,20 @@ var (
 			Help: "Number of opened TCP connections",
 		},
 	)
+	teardownDurationsHisto = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: Prefix + "teardown_durations_histogram_seconds",
+		Help: "Connection teardown duration distributions.",
+		Buckets: []float64{1.0, 2.0, 4.0, 8.0, 16.0, 32.0},
+	})
+	bytesCopiedHisto = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: Prefix + "bytes_copied_histogram",
+		Help: "Bytes copied distributions.",
+		Buckets: []float64{1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0},
+	})
+		teardownTimeoutCtr = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: Prefix + "teardown_timeouts",
+		Help: "Number of connection teardown timeouts.",
+	})
 )
 
 // IncConnections increments the total connections counter
@@ -31,4 +44,16 @@ func DecConnections() {
 // ConnectionTime gather the duration of a connection
 func ConnectionTime(d time.Duration) {
 	connDurationsHisto.Observe(d.Seconds())
+}
+
+func TeardownTime(d time.Duration) {
+	teardownDurationsHisto.Observe(d.Seconds())
+}
+
+func BytesCopied(bytes int64) {
+	bytesCopiedHisto.Observe(float64(bytes))
+}
+
+func TeardownTimeout() {
+	teardownTimeoutCtr.Inc()
 }

--- a/metrics/connections.go
+++ b/metrics/connections.go
@@ -16,6 +16,13 @@ var (
 			Help: "Number of opened TCP connections",
 		},
 	)
+	backendConnGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: Prefix + "opened_backend_connections_count",
+			Help: "Number of established backend TCP connections",
+		},
+		[]string{"backend"},
+	)
 	teardownDurationsHisto = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: Prefix + "teardown_durations_histogram_seconds",
 		Help: "Connection teardown duration distributions.",
@@ -26,7 +33,7 @@ var (
 		Help: "Bytes copied distributions.",
 		Buckets: []float64{1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0},
 	})
-		teardownTimeoutCtr = prometheus.NewCounter(prometheus.CounterOpts{
+	teardownTimeoutCtr = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: Prefix + "teardown_timeouts",
 		Help: "Number of connection teardown timeouts.",
 	})
@@ -39,6 +46,18 @@ func IncConnections() {
 
 func DecConnections() {
 	connGauge.Dec()
+}
+
+// IncBackendConnections increments the total connections currently established
+// for a given backend
+func IncBackendConnections(backend string) {
+	g, _ := backendConnGauge.GetMetricWithLabelValues(backend)
+	g.Inc()
+}
+
+func DecBackendConnections(backend string) {
+	g, _ := backendConnGauge.GetMetricWithLabelValues(backend)
+	g.Dec()
 }
 
 // ConnectionTime gather the duration of a connection

--- a/metrics/init.go
+++ b/metrics/init.go
@@ -9,6 +9,9 @@ const (
 func init() {
 	prometheus.MustRegister(connDurationsHisto)
 	prometheus.MustRegister(connGauge)
+	prometheus.MustRegister(backendConnGauge)
+	prometheus.MustRegister(backendBytesSentCtr)
+	prometheus.MustRegister(backendBytesRcvdCtr)
 	prometheus.MustRegister(errorCounterVec)
 	prometheus.MustRegister(backendGauge)
 	prometheus.MustRegister(teardownDurationsHisto)

--- a/metrics/init.go
+++ b/metrics/init.go
@@ -11,4 +11,7 @@ func init() {
 	prometheus.MustRegister(connGauge)
 	prometheus.MustRegister(errorCounterVec)
 	prometheus.MustRegister(backendGauge)
+	prometheus.MustRegister(teardownDurationsHisto)
+	prometheus.MustRegister(bytesCopiedHisto)
+	prometheus.MustRegister(teardownTimeoutCtr)
 }

--- a/support/Dockerfile
+++ b/support/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian
+
+RUN mkdir -p /pipeline/source
+ADD build/bin/k8sniff /pipeline/source
+
+CMD ["/pipeline/source/k8sniff"]


### PR DESCRIPTION
Every ~30 minutes, the Informer Cache that k8sniff uses to track ingress and service resources sends out "update" events for all objects (which can number in the thousands). K8sniff triggers a full state re-sync for each of those updates, causing both CPU and memory to spike (up to 200% and 15GB as observed on prod). It turns out that those events are not real updates: the old and new objects are the same. One theory is that the etcd/k8s-api machinery periodically invalidates revision versions (used by Watch API) older than a certain time, causing the Informer Cache to invalidate its internal state and force clients to resync. This has not yet been confirmed.

This change simply checks to see if the old and new objects are the same, and skip the k8sniff server state update if they are. Tests on the staging cluster have shown that the CPU and memory spikes are now gone.